### PR TITLE
fix: add spec.version for plugin.yaml

### DIFF
--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -18,3 +18,4 @@ spec:
   license:
     - name: "GPL-3.0"
       url: "https://github.com/halo-dev/plugin-starter/blob/main/LICENSE"
+  version: "1.0.0"


### PR DESCRIPTION
在 plugin.yaml 中补充缺少的 spec.version 字段。