### PR TITLE
chore: bump devtools version to 0.0.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id "com.github.node-gradle.node" version "3.3.0"
     id "io.freefair.lombok" version "8.0.1"
-    id "run.halo.plugin.devtools" version "0.0.4"
+    id "run.halo.plugin.devtools" version "0.0.7"
 }
 
 group 'run.halo.starter'


### PR DESCRIPTION
### What this PR does?
升级 devtools 版本到 0.0.7

```release-note
None
```