### PR TITLE
Upgrade the version of the action steps

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,20 +11,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           cache: 'gradle'
           java-version: 17
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v3
         name: Install pnpm
         id: pnpm-install
         with:
@@ -33,8 +33,9 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-      - uses: actions/cache@v3
+          pnpm_cache_dir=`pnpm store path`
+          echo "pnpm_cache_dir=$pnpm_cache_dir" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -52,7 +53,7 @@ jobs:
           sed -i "s/version=.*-SNAPSHOT$/version=$version/1" gradle.properties
           ./gradlew clean build -x test
       - name: Archive plugin-starter jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: plugin-starter
           path: |
@@ -65,7 +66,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download plugin-starter jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: plugin-starter
           path: build/libs
@@ -80,7 +81,7 @@ jobs:
           echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
           echo "RELEASE_ID=${{ github.event.release.id }}" >> $GITHUB_ENV
       - name: Upload a Release Asset
-        uses: actions/github-script@v2
+        uses: actions/github-script@v7
         if: github.event_name == 'release'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
根据Github的相关文档说明，在后期会弃用set-output的方式设置Action的返回值，因此按照文档的方式对设置返回值的逻辑进行修改，同时更新目前使用到的Actions的版本，规避set-output的问题同时修复低版本Actions中可能存在的漏洞

Github文档： [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

```release-note
None
```
