### PR TITLE
Bump Halo devtools to 0.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id "io.freefair.lombok" version "8.13"
-    id "run.halo.plugin.devtools" version "0.6.0"
+    id "run.halo.plugin.devtools" version "0.6.1"
 }
 
 group 'run.halo.starter'


### PR DESCRIPTION
```release-note
升级 Halo 开发者工具至 0.6.1
```