### PR TITLE
Add missing ui-path for cd workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
     with:
+      ui-path: ui
       pnpm-version: 9
       node-version: 22
       java-version: 21


### PR DESCRIPTION
This PR adds `ui-path` configuration for cd workflow to resolve release issue.

See https://github.com/halo-dev/plugin-starter/actions/runs/15917278002/job/44897118472#step:3:48 for more.

```release-note
解决无法正常发布的问题
````
